### PR TITLE
Disabled check that sum of relative grades is 100

### DIFF
--- a/moodlexport/python_to_moodle.py
+++ b/moodlexport/python_to_moodle.py
@@ -242,16 +242,17 @@ class Question():
             self.dict[field] = {**field_structure['attribute'], **{"text": value}} # concatenation needs Python >= 3.5
     
     def multi_answer(self): # unlocks the multiple answer mode
-        self.dict["single"] = "false" #TBA : check sum fractions is 100 or all 0 etc
+        self.dict["single"] = "false" 
         
     def has_answer(self):
         return (self.get_type() == "multichoice") and self.structure['answer']['isset']
     
-    def cumulated_grade(self): # sums the fractions of grade in the answers
+    def cumulated_grade_correct(self): # sums the fractions of grade of correct answers
         if self.structure['answer']['isset']:
             s = 0
             for answer in self.structure['answer']['list']:
-                s += answer.structure['relativegrade']
+            	if answer.structure['relativegrade'] > 0:
+                	s += answer.structure['relativegrade']
             return s
         else:
             return 100
@@ -271,8 +272,8 @@ class Question():
                     self._set('single', 'false')
                 elif answer.structure['relativegrade'] == 100: # we have a unique solution
                     self._set('single', 'true')
-                if self.cumulated_grade() != 100:
-                    raise ValueError('In a multichoice Question, the sum of the relative grades/percentages of the Answers must be exactly 100, but here is '+str(self.cumulated_grade()))
+                if self.cumulated_grade_correct() != 100:
+                    raise ValueError('In a multichoice Question, the sum of the relative grades/percentages of the correct answers must be exactly 100, but here is '+str(self.cumulated_grade_correct()))
                 
     
     def save(self, optional_name="Default-category-name"): 
@@ -329,7 +330,7 @@ class Answer():
     def text(self, text):
         self.structure['text'] = text
         
-    def relativegrade(self, grade):# must be a number (int?) between 0 and 100, decribing how much it is worth. Or a bool.
+    def relativegrade(self, grade):# must be a number (int?) between -100 and 100, decribing how much it is worth. Or a bool.
         grade = bool_to_grade(grade)
         self.structure['relativegrade'] = bool_to_grade(grade) 
         
@@ -340,7 +341,7 @@ class Answer():
         self.relativegrade(100)
         
     def isfalse(self): # Says that this answer is not good
-        self.relativegrade(0)
+      	self.relativegrade(0)
 
 # GET FIELDS         
     def get_text(self):
@@ -371,8 +372,8 @@ class Answer():
         else:
             question.structure["answer"]["isset"] = True
             question.structure["answer"]["list"].append(self)
-            if question.cumulated_grade() > 100:
-                raise ValueError("In this Question the sum of relative grades/percentages of the Answers appears to be >100.")
+            if question.cumulated_grade_correct() > 100:
+                raise ValueError("In this Question the sum of relative grades/percentages of the correct answers appears to be >100.")
 
 # NEEDED FUNCTIONS
 def bool_to_grade(grade):
@@ -385,8 +386,8 @@ def bool_to_grade(grade):
             return 0
     else: # it is already an integer (we hope so)
         grade = int(grade)
-        if grade > 100 or grade < 0:
-            raise ValueError('For an Answer, the (relative) grade must be a number between 0 and 100, representing its precentage of "truthness".')
+        if grade > 100 or grade < -100:
+            raise ValueError('For an answer, the (relative) grade must be a number between -100 and 100, representing the percentage of points gained/lost by marking it as correct.')
         else:
             return grade
 


### PR DESCRIPTION
Hey, first of all thanks for your work on this package! It's very useful to me. However, I don't like the constraint that the sum of the relative grades must sum to 100. Whenever that is the case, one can obtain 100% of the points for the question by simply marking every option as correct. If relative grades are not allowed to assume negative values, that will always be the case. I therefore made the following small changes to the package:

- Allow relative grades to be integers between -100 and 100
- Instead of checking that the sum of the relative grades of *all* answers is 100, check that the sum of the relative grades of the *correct* answers is 100

I felt that this would be more reasonable default behavior, so I submitted this pull request.