### PR TITLE
Add numpy and beautifulsoup4 to setuptools required packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setuptools.setup(
     python_requires='>=3.7',
     install_requires=[
     'texsoup == 0.2.1',
-    'xmltodict >= 0.12.0'
+    'xmltodict >= 0.12.0',
+    'numpy >= 1.18.0',
+    'beautifulsoup4 >= 4.8.0'
     ],
     include_package_data=True,
 )


### PR DESCRIPTION
When I installed moodlexport in a fresh virtual environment and tried to run the example notebooks I found that these 2 packages were not installed so I have added them to setup.py so that others don't run into the same problem.