### PR TITLE
Only allow grade percentages for multiple choice questions that moodle will accept

### DIFF
--- a/moodlexport/python_to_moodle.py
+++ b/moodlexport/python_to_moodle.py
@@ -167,8 +167,6 @@ class Question():
                 self.dict["answer"].append(answer.dict)
                 if answer.structure['relativegrade'] != 0 and answer.structure['relativegrade'] != 100: # we have multiple solutions
                     self._set('single', 'false')
-                elif answer.structure['relativegrade'] == 100: # we have a unique solution
-                    self._set('single', 'true')
                 if self.cumulated_grade_correct() != 100:
                     raise ValueError('In a multichoice Question, the sum of the relative grades/percentages of the correct answers must be exactly 100, but here is '+str(self.cumulated_grade_correct()))
                 

--- a/moodlexport/templates/latextomoodle.sty
+++ b/moodlexport/templates/latextomoodle.sty
@@ -7,10 +7,11 @@
 \newcommand{\badanswer}{$\Box$~}
 
 \newcommand{\answer}[2][]{
-	\ifthenelse{#1 > 0}
-		{~\newline \noindent \goodanswer #2}
-		{~\newline \noindent \badanswer #2}
+  \ifthenelse{\lengthtest{#1 pt > 0.0pt}}
+    {~\newline \noindent \goodanswer #2 ~\hfill~(${#1} \%$)~}
+    {~\newline \noindent \badanswer #2  ~\hfill~(${#1} \%$)~}
 }
+
 
 %%%%% CATEGORY
 \newenvironment{category}[1][]{ \newpage \section{Catégorie: #1}   }{\bigskip}


### PR DESCRIPTION
Hi Guillaume,

hope you are doing well. Again, I'd like this package to behave a little differently when it comes to the grading of multiple choice questions, and I took the liberty of opening a pull request that would bring the changes I'd like to see.

First of all, I changed something that I'd call a bug. In the previous version, the following could would generate a single-choice question:

```python
category = Category("Addition")

question = Question("multichoice")
question.text("Which of the following are equal to 1+1?")
question.single(False)
question.answer("2",100.0)
question.answer("3",-100.0)
question.answer("4",-100.0)
question.answer("1.5",-100.0)
question.addto(category)

``` 
Note that even though we explicitly set `question.single` to `False`, the following lines in `python_to_moodle.py` would cause the question to be converted to a single-choice question:
```python
elif answer.structure['relativegrade'] == 100: # we have a unique solution
    self._set('single', 'true')
```
I removed those lines accordingly.

What's more, moodle will only accept certain grade percentages when importing .xml files. This is a matter of taste, but personally I believe it would be best if this package would compile a question without warning or error if and only if it is possible to import that question into moodle without warning or error. I changed the exception handling accordingly, such that the package will only accept those values that moodle will accept. The following code

```python
category = Category("Addition")

question = Question("multichoice")
question.text("Which of the following are equal to 1+1?")
question.single(False)
question.answer("3-1",33.3333)
question.answer("2",33.3333)
question.answer("4-2",33.3333)
question.answer("1",-50.0)
question.addto(category)

category.save()
``` 
will now throw the following error:
```python
ValueError: For an answer, the value 33.3333 for a (relative) grade is not accepted by moodle. Accepted values are [-100.0, -90.0, -83.33333, -80.0, -75.0, -70.0, -66.66667, -60.0, -50.0, -50.0, -40.0, -33.33333, -30.0, -25.0, -20.0, -16.66667, -14.28571, -12.5, -11.11111, -10.0, 0.0, 10.0, 11.11111, 12.5, 14.28571, 16.66667, 20.0, 25.0, 30.0, 33.33333, 40.0, 50.0, 50.0, 60.0, 66.66667, 70.0, 75.0, 80.0, 83.33333, 90.0, 100.0]
```
However, 
```python
category = Category("Addition")

question = Question("multichoice")
question.text("Which of the following are equal to 1+1?")
question.single(False)
question.answer("3-1",33.33333)
question.answer("2",33.33333)
question.answer("4-2",33.33333)
question.answer("1",-50.0)
question.addto(category)

category.save()
```
will work as intended. I also changed the exception handling concerning the sum of the correct answers, which now only requires the sum of the grade percentages of the correct answers to add up to 100.0 with a tolerance of 0.01. Furthermore, the default type of `grade` is now `float` instead of `int` throughout. One consequence of this is that I had to change the comparison in `latextomoodle.sty` which determines whether an answer is good or bad. I also added the percentages of the grade gained/lost by marking an answer as correct in the .tex file, which I find useful for multiple choice questions. However, there is an alignment issue which I don't understand: 

![Screenshot from 2021-01-13 12-36-03](https://user-images.githubusercontent.com/17217480/104447399-090c6b00-559c-11eb-80d5-f3d8ff7b14fc.png)

Here, the percentage of the last answer is not aligned to the others.


