### PR TITLE
Add `left` and `right` values to style option (includegraphics function)

### DIFF
--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -163,6 +163,8 @@ Options:
 - `width` and `height` (integer). Modify the size of the image, in pixels. If no argument is passed, the image is displayed in its original shape.
 - `style` (string). Two possible values:
     * `"centered"` (default). The image is displayed in a new line and centered.
+    * `"left"`. The image is displayed in a new line with left alignment.
+    * `"right"`. The image is displayed in a new line with right alignment.
     * `"inline"`. The image is displayed next to the text.
 
 ### Main commands from Latex


### PR DESCRIPTION
The function `includegraphics` has the option `style`, which currently accepts the values 'centered' and 'inline'.

However, in some cases, it can be convenient to have a left alignment of the figure. Right-alignment is not that useful, but it may also be added to the acceptable values for the shake of completeness.

So this pull request aims at adding the following value for such a keyword:

 * 'left': image to new line a left-aligned
 * 'right': image to new line a right-aligned