### PR TITLE
Single-answer question with bullets in latex

### DIFF
--- a/moodlexport/python_to_latex.py
+++ b/moodlexport/python_to_latex.py
@@ -48,7 +48,10 @@ def latexfile_append_question(question): #Given a Question return the latex stri
     if question.has_answer():
         content += '\n'
         for answer in question.get_answer():
-            content += latexfile_command('answer', answer.get_text(), str(answer.get_relativegrade()))
+            if question.get_single():
+                content += latexfile_command('answerO', answer.get_text(), str(answer.get_relativegrade()))
+            else:
+                content += latexfile_command('answer', answer.get_text(), str(answer.get_relativegrade()))
     content += '\n'
     for field in question.structure:
         if field not in ['@type', 'questiontext', 'answer', 'name']: # keep it for later/before

--- a/moodlexport/templates/latextomoodle.sty
+++ b/moodlexport/templates/latextomoodle.sty
@@ -3,17 +3,25 @@
 %%%%% ANSWER
 \usepackage{ifthen}
 \usepackage{wasysym}
+\usepackage{textcomp}
 \newcommand{\goodanswer}{$\XBox$~}
 \newcommand{\badanswer}{$\Box$~}
+\newcommand{\goodanswerO}{{\Large\textbullet}}
+\newcommand{\badanswerO}{{\Large\textopenbullet}}
 
 \newcommand{\answer}[2][]{%
   \ifthenelse{\lengthtest{#1 pt > 0.0pt}}
     {\leavevmode\newline \noindent \goodanswer #2 \hfill (${#1} \%$)}
     {\leavevmode\newline \noindent \badanswer #2 \hfill (${#1} \%$)}
 }
+\newcommand{\answerO}[2][]{%
+  \ifthenelse{\lengthtest{#1 pt > 0.0pt}}
+    {\leavevmode\newline \noindent \goodanswerO #2 \hfill (${#1} \%$)}
+    {\leavevmode\newline \noindent \badanswerO #2 \hfill (${#1} \%$)}
+}
 
 %%%%% CATEGORY
-\newenvironment{category}[1][]{ \newpage \section{Catégorie: #1}   }{\bigskip}
+\newenvironment{category}[1][]{ \newpage \section{Category: #1}   }{\bigskip}
 
 \newcommand{\name}[1]{}
 \renewcommand{\description}[1]{}
@@ -26,7 +34,7 @@
 
 % Dummy commands
 \newcommand{\type}[1]{}
-\newcommand{\generalfeedback}[1]{}
+\newcommand{\generalfeedback}[1]{\begin{tcolorbox}#1\end{tcolorbox}}
 \newcommand{\grade}[1]{}
 %\renewcommand{\penalty}[1]{}
 \newcommand{\hidden}[1]{}


### PR DESCRIPTION
Use circles instead of squares to show single-answer questions in latex
(similar to the way they are displayed in Moodle)

This was implemented by adding a new command into the latex template for the answers with circles:
`\goodanswerO`
`\badanswerO`
The new commands are then used from `python_to_latex.py`
